### PR TITLE
String replace otpye

### DIFF
--- a/Simperium.xcodeproj/project.pbxproj
+++ b/Simperium.xcodeproj/project.pbxproj
@@ -229,6 +229,7 @@
 		B5F4C84518FC1B04009F8643 /* NSError+Simperium.h in Headers */ = {isa = PBXBuildFile; fileRef = B5F4C84318FC1B04009F8643 /* NSError+Simperium.h */; };
 		B5F4C84618FC1B04009F8643 /* NSError+Simperium.m in Sources */ = {isa = PBXBuildFile; fileRef = B5F4C84418FC1B04009F8643 /* NSError+Simperium.m */; };
 		B5F65F7A1847DE0100CEF48D /* SPManagedObject+Internals.h in Headers */ = {isa = PBXBuildFile; fileRef = B5F65F791847DE0100CEF48D /* SPManagedObject+Internals.h */; };
+		BD591EEC1DAEA507003CF2CD /* SPMemberTextTest.m in Sources */ = {isa = PBXBuildFile; fileRef = BD591EEB1DAEA507003CF2CD /* SPMemberTextTest.m */; };
 		E265DBD017CD3E0A00070550 /* SPTOSViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = E265DBCE17CD3E0A00070550 /* SPTOSViewController.h */; };
 		E265DBD117CD3E0A00070550 /* SPTOSViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = E265DBCF17CD3E0A00070550 /* SPTOSViewController.m */; };
 /* End PBXBuildFile section */
@@ -460,6 +461,7 @@
 		B5F4C84418FC1B04009F8643 /* NSError+Simperium.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSError+Simperium.m"; sourceTree = "<group>"; };
 		B5F4FE6818A3D7B8006F50C5 /* Simperium.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = Simperium.podspec; sourceTree = SOURCE_ROOT; };
 		B5F65F791847DE0100CEF48D /* SPManagedObject+Internals.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "SPManagedObject+Internals.h"; sourceTree = "<group>"; };
+		BD591EEB1DAEA507003CF2CD /* SPMemberTextTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPMemberTextTest.m; sourceTree = "<group>"; };
 		E265DBCE17CD3E0A00070550 /* SPTOSViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SPTOSViewController.h; sourceTree = "<group>"; };
 		E265DBCF17CD3E0A00070550 /* SPTOSViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SPTOSViewController.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -894,6 +896,7 @@
 				B597DD58183128FE005E95D7 /* SPWebSocketInterfaceTests.m */,
 				B5DE0E0E1850D0200080C44D /* SPCoreDataStorageTests.m */,
 				B5DF229418B41FB700874C75 /* SPMemberJSONTests.m */,
+				BD591EEB1DAEA507003CF2CD /* SPMemberTextTest.m */,
 				B5E662A918F492AD0065EF11 /* NSStringSimperiumTest.m */,
 				B57FA3B11900568A00957205 /* SPRelationshipResolverTests.m */,
 				B5F068B0186223DF00D0D7B7 /* DiffMatchPatchTest.m */,
@@ -1317,6 +1320,7 @@
 				B5B69C0318325B2C001F0DE1 /* MockSimperium.m in Sources */,
 				B5549FE6184581BF007EA226 /* SPThreadsafeMutableSetTests.m in Sources */,
 				B5E662AA18F492AD0065EF11 /* NSStringSimperiumTest.m in Sources */,
+				BD591EEC1DAEA507003CF2CD /* SPMemberTextTest.m in Sources */,
 				B5C7D7F9183411B900E9109C /* SPPersistentMutableDictionaryTests.m in Sources */,
 				B565ECAA1832940B00D162FF /* XCTestCase+Simperium.m in Sources */,
 				B5A57EAC1951C128006E2455 /* SPIndexProcessorTests.m in Sources */,

--- a/Simperium/SPCoreDataExporter.m
+++ b/Simperium/SPCoreDataExporter.m
@@ -83,6 +83,7 @@ static SPLogLevels logLevel = SPLogLevelsInfo;
 
         [member setObject:[attr name] forKey:@"name"];
         [member setObject:@"default" forKey:@"resolutionPolicy"];
+        member[@"otype"] = attr.userInfo[@"otype"];
         NSString *type = [self simperiumTypeForAttribute: attr];
         NSAssert1(type != nil, @"Simperium couldn't load member %@ (unsupported type)", [attr name]);
         [member setObject: type forKey:@"type"];

--- a/Simperium/SPCoreDataExporter.m
+++ b/Simperium/SPCoreDataExporter.m
@@ -9,7 +9,7 @@
 #import "SPCoreDataExporter.h"
 #import "SPManagedObject.h"
 #import "SPLogger.h"
-
+#import "SPMember.h"
 
 
 #pragma mark ====================================================================================
@@ -17,13 +17,22 @@
 #pragma mark ====================================================================================
 
 static SPLogLevels logLevel = SPLogLevelsInfo;
-
+NSString * const OP_REPLACE_IDENTIFIER = @"replace";
 
 #pragma mark ====================================================================================
 #pragma mark SPCoreDataExporter
 #pragma mark ====================================================================================
 
 @implementation SPCoreDataExporter
+
++ (NSString *)operationTypeForIdentifier:(NSString *)opIdentifier
+{
+    if ([opIdentifier isEqualToString:OP_REPLACE_IDENTIFIER]) {
+        return OP_REPLACE;
+    }
+    
+    return nil;
+}
 
 - (NSString *)simperiumTypeForAttribute:(NSAttributeDescription *)attribute
 {
@@ -83,7 +92,7 @@ static SPLogLevels logLevel = SPLogLevelsInfo;
 
         [member setObject:[attr name] forKey:@"name"];
         [member setObject:@"default" forKey:@"resolutionPolicy"];
-        member[@"otype"] = attr.userInfo[@"otype"];
+        member[@"otype"] = [[self class] operationTypeForIdentifier:attr.userInfo[@"otype"]];
         NSString *type = [self simperiumTypeForAttribute: attr];
         NSAssert1(type != nil, @"Simperium couldn't load member %@ (unsupported type)", [attr name]);
         [member setObject: type forKey:@"type"];

--- a/Simperium/SPMember.h
+++ b/Simperium/SPMember.h
@@ -31,7 +31,7 @@ extern NSString * const OP_STRING;
     NSString *valueTransformerName;
     id modelDefaultValue;
 }
-
+@property (nonatomic, readonly, strong) NSString *otype;
 @property (nonatomic, readonly, strong) NSString *keyName;
 @property (nonatomic, readonly, strong) NSString *valueTransformerName;
 @property (nonatomic, readonly, strong) id modelDefaultValue;

--- a/Simperium/SPMember.m
+++ b/Simperium/SPMember.m
@@ -30,18 +30,6 @@ NSString * const OP_LIST_DMP        = @"dL";
 NSString * const OP_OBJECT          = @"O";
 NSString * const OP_STRING          = @"d";
 
-
-NSString * const OP_REPLACE_IDENTIFIER = @"replace";
-
-+ (NSString *)operationTypeForIdentifier:(NSString *)opIdentifier
-{
-    if ([opIdentifier isEqualToString:OP_REPLACE_IDENTIFIER]) {
-        return OP_REPLACE;
-    }
-    
-    return nil;
-}
-
 - (instancetype)initFromDictionary:(NSDictionary *)dict
 {
     self = [self init];
@@ -50,7 +38,7 @@ NSString * const OP_REPLACE_IDENTIFIER = @"replace";
         type = [[dict objectForKey:@"type"] copy];
         valueTransformerName = [[dict objectForKey:@"valueTransformerName"] copy];
         modelDefaultValue = [[dict objectForKey:@"defaultValue"] copy];
-        _otype = [[self class] operationTypeForIdentifier:[dict objectForKey:@"otype"]];
+        _otype = [dict objectForKey:@"otype"];
     }
     
     return self;

--- a/Simperium/SPMember.m
+++ b/Simperium/SPMember.m
@@ -30,6 +30,18 @@ NSString * const OP_LIST_DMP        = @"dL";
 NSString * const OP_OBJECT          = @"O";
 NSString * const OP_STRING          = @"d";
 
+
+NSString * const OP_REPLACE_IDENTIFIER = @"replace";
+
++ (NSString *)operationTypeForIdentifier:(NSString *)opIdentifier
+{
+    if ([opIdentifier isEqualToString:OP_REPLACE_IDENTIFIER]) {
+        return OP_REPLACE;
+    }
+    
+    return nil;
+}
+
 - (instancetype)initFromDictionary:(NSDictionary *)dict
 {
     self = [self init];
@@ -38,6 +50,7 @@ NSString * const OP_STRING          = @"d";
         type = [[dict objectForKey:@"type"] copy];
         valueTransformerName = [[dict objectForKey:@"valueTransformerName"] copy];
         modelDefaultValue = [[dict objectForKey:@"defaultValue"] copy];
+        _otype = [[self class] operationTypeForIdentifier:[dict objectForKey:@"otype"]];
     }
     
     return self;

--- a/Simperium/SPMemberText.m
+++ b/Simperium/SPMemberText.m
@@ -44,10 +44,7 @@
         }
         
         // Construct the diff in the expected format
-        return @{
-                 OP_OP : OP_REPLACE,
-                 OP_VALUE : otherValue
-                 };
+        return [NSDictionary dictionaryWithObjectsAndKeys:OP_REPLACE,OP_OP,otherValue,OP_VALUE, nil];
     }
     
     // Use DiffMatchPatch to find the diff

--- a/Simperium/SPMemberText.m
+++ b/Simperium/SPMemberText.m
@@ -74,11 +74,6 @@
     // if ([thisValue length] == 0)
     //    return otherValue;
     
-    //If otype is replace then avoid diff
-    if ([self.otype isEqualToString:OP_REPLACE]) {
-        return [otherValue copy];
-    }
-    
     NSMutableArray *diffs   = [self.dmp diff_fromDeltaWithText:thisValue andDelta:otherValue error:error];
     NSMutableArray *patches = [self.dmp patch_makeFromOldString:thisValue andDiffs:diffs];
     NSArray *result         = [self.dmp patch_apply:patches toString:thisValue];
@@ -87,11 +82,6 @@
 }
 
 - (NSDictionary *)transform:(id)thisValue otherValue:(id)otherValue oldValue:(id)oldValue error:(NSError **)error {
-    
-    //If otype is replace then avoid applying diff
-    if ([self.otype isEqualToString:OP_REPLACE]) {
-        return [NSDictionary dictionaryWithObjectsAndKeys:OP_REPLACE,OP_OP,thisValue,OP_VALUE, nil];
-    }
     
     // Calculate the delta from the Ghost to the Local + Remote values. Treat any error here as fatal
     NSMutableArray *thisDiffs       = [self.dmp diff_fromDeltaWithText:oldValue andDelta:thisValue error:error];

--- a/SimperiumTests/SPMemberTextTest.m
+++ b/SimperiumTests/SPMemberTextTest.m
@@ -39,25 +39,8 @@
                                      OP_VALUE : valueC
                                      };
     
-    NSString *outputDiffAB_on_valueA = [self.textMember applyDiff:valueA otherValue:diffAB[OP_VALUE] error:nil];
-    NSString *expectedOutputDiffAB_on_valueA = [valueB copy];
-    
-    NSString *outputDiffAC_on_valueA = [self.textMember applyDiff:valueA otherValue:diffAC[OP_VALUE] error:nil];
-    NSString *expectedOutputDiffAC_on_valueA = [valueC copy];
-    
-    NSString *outputDiffAC_on_outputDiffAB_on_valueA = [self.textMember applyDiff:outputDiffAB_on_valueA otherValue:diffAC[OP_VALUE] error:nil];
-    NSString *expectedOutputDiffAC_on_outputDiffAB_on_valueA = [valueC copy];
-    
-    NSString *outputDiffAB_on_outputDiffAC_on_valueA = [self.textMember applyDiff:outputDiffAC_on_valueA otherValue:diffAB[OP_VALUE] error:nil];
-    NSString *expectedOutputDiffAB_on_outputDiffAC_on_valueA = [valueB copy];
-    
-    
     XCTAssertEqualObjects(diffAB, expectedDiffAB, @"Error obtaining TextReplace Diff");
     XCTAssertEqualObjects(diffAC, expectedDiffAC, @"Error obtaining TextReplace Diff");
-    XCTAssertEqualObjects(outputDiffAB_on_valueA, expectedOutputDiffAB_on_valueA, @"Error applying TextReplace Diff");
-    XCTAssertEqualObjects(outputDiffAC_on_valueA, expectedOutputDiffAC_on_valueA, @"Error applying TextReplace Diff");
-    XCTAssertEqualObjects(outputDiffAC_on_outputDiffAB_on_valueA, expectedOutputDiffAC_on_outputDiffAB_on_valueA, @"Error applying TextReplace Diff");
-    XCTAssertEqualObjects(outputDiffAB_on_outputDiffAC_on_valueA, expectedOutputDiffAB_on_outputDiffAC_on_valueA, @"Error applying TextReplace Diff");
 }
 
 @end

--- a/SimperiumTests/SPMemberTextTest.m
+++ b/SimperiumTests/SPMemberTextTest.m
@@ -1,0 +1,63 @@
+//
+//  SPMemberTextTest.m
+//  Simperium
+//
+//  Created by Lukman Sanusi on 10/12/16.
+//  Copyright © 2016 Simperium. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "SPMemberText.h"
+
+@interface SPMemberTextTest : XCTestCase
+@property (nonatomic, strong) SPMemberText *textMember;
+@end
+
+@implementation SPMemberTextTest
+
+- (void)setUp{
+    self.textMember = [[SPMemberText alloc] initFromDictionary:@{ @"type" : @"text",
+                                                                  @"name" : @"test",
+                                                                  @"otype" : OP_REPLACE
+                                                                  }];
+}
+
+- (void)testTextReplaceOperation {
+    NSString *valueA = @"2016-10";
+    NSString *valueB = @"2016-05";
+    NSString *valueC = @"2016-04";
+    
+    NSDictionary *diffAB = [self.textMember diff:valueA otherValue:valueB];
+    NSDictionary *expectedDiffAB = @{
+                                     OP_OP : OP_REPLACE,
+                                     OP_VALUE : valueB
+                                     };
+    
+    NSDictionary *diffAC = [self.textMember diff:valueA otherValue:valueC];
+    NSDictionary *expectedDiffAC = @{
+                                     OP_OP : OP_REPLACE,
+                                     OP_VALUE : valueC
+                                     };
+    
+    NSString *outputDiffAB_on_valueA = [self.textMember applyDiff:valueA otherValue:diffAB[OP_VALUE] error:nil];
+    NSString *expectedOutputDiffAB_on_valueA = [valueB copy];
+    
+    NSString *outputDiffAC_on_valueA = [self.textMember applyDiff:valueA otherValue:diffAC[OP_VALUE] error:nil];
+    NSString *expectedOutputDiffAC_on_valueA = [valueC copy];
+    
+    NSString *outputDiffAC_on_outputDiffAB_on_valueA = [self.textMember applyDiff:outputDiffAB_on_valueA otherValue:diffAC[OP_VALUE] error:nil];
+    NSString *expectedOutputDiffAC_on_outputDiffAB_on_valueA = [valueC copy];
+    
+    NSString *outputDiffAB_on_outputDiffAC_on_valueA = [self.textMember applyDiff:outputDiffAC_on_valueA otherValue:diffAB[OP_VALUE] error:nil];
+    NSString *expectedOutputDiffAB_on_outputDiffAC_on_valueA = [valueB copy];
+    
+    
+    XCTAssertEqualObjects(diffAB, expectedDiffAB, @"Error obtaining TextReplace Diff");
+    XCTAssertEqualObjects(diffAC, expectedDiffAC, @"Error obtaining TextReplace Diff");
+    XCTAssertEqualObjects(outputDiffAB_on_valueA, expectedOutputDiffAB_on_valueA, @"Error applying TextReplace Diff");
+    XCTAssertEqualObjects(outputDiffAC_on_valueA, expectedOutputDiffAC_on_valueA, @"Error applying TextReplace Diff");
+    XCTAssertEqualObjects(outputDiffAC_on_outputDiffAB_on_valueA, expectedOutputDiffAC_on_outputDiffAB_on_valueA, @"Error applying TextReplace Diff");
+    XCTAssertEqualObjects(outputDiffAB_on_outputDiffAC_on_valueA, expectedOutputDiffAB_on_outputDiffAC_on_valueA, @"Error applying TextReplace Diff");
+}
+
+@end


### PR DESCRIPTION
A solution for https://foreflight.atlassian.net/browse/LOGBOOK-453

now have the option to inject the preferred operation type much like we do server side. We can now add the otype through the userinfo "otype" key in the core data model. it only accepts replace for now.

![screen shot 2016-10-12 at 1 05 36 pm](https://cloud.githubusercontent.com/assets/4479823/19321931/9f695656-907c-11e6-8feb-7c1d52b31f0e.png)

https://github.com/Simperium/simperium-ios/issues/456
