### PR TITLE
Fix duplicate NSManagedObjects when processing version data

### DIFF
--- a/Simperium/SPIndexProcessor.m
+++ b/Simperium/SPIndexProcessor.m
@@ -195,7 +195,7 @@ typedef NS_ENUM(NSInteger, SPVersion) {
             [objectKeys addObject:versionData[0]];
         }
         
-        NSDictionary *objects = [storage faultObjectsForKeys:objectKeys bucketName:bucket.name];
+        NSMutableDictionary *objects = [[storage faultObjectsForKeys:objectKeys bucketName:bucket.name] mutableCopy];
         
         // Process all version data
         for (NSArray *versionData in versions)
@@ -212,6 +212,7 @@ typedef NS_ENUM(NSInteger, SPVersion) {
             // The object doesn't exist locally yet, so create it
             if (!object) {
                 object          = [storage insertNewObjectForBucketName:bucket.name simperiumKey:key];
+                objects[key] = object;
                 object.bucket   = bucket; // set it manually since it won't be set automatically yet
                 [object loadMemberData:data];
                 


### PR DESCRIPTION
Issue observed: Assume there exist a bucket `A`. On signin the latests version for bucket A is requested. Versions of entries in A is processed but the websocket gets disconnected before the process is completed. There is a batch of objects waiting to be processed. Upon reconnecting, there is another request for the latest version for objects that may already be in the queue to be processed into coredata. These duplicate version can lead to duplicate objects getting created in core data.

Fix was applied in the `-[SPIndexProcessor processVersions: bucket: changeHandler:]`

Assume `objectKeys` contained a value `x` and a value `y` such that `x` == `y`
and there is no managed object with simperium key `x` (for `m` in `objects`, `m.simperiumKey` != `x`). Then when iterating over `versions`, multiple coredata objects with the same
simperium key `x` will be created.

The fix here is to create the object once and update the objects array
so that the created object may be reused if needed.