### PR TITLE
Prevent crash when change for relationship is NSNull instead of nil

### DIFF
--- a/Simperium/SPMemberEntity.m
+++ b/Simperium/SPMemberEntity.m
@@ -60,7 +60,8 @@ static SPLogLevels logLevel = SPLogLevelsWarn;
     NSString *simperiumKey = dict[key];
     
     // With optional 1 to 1 relationships, there might not be an object
-    if (!simperiumKey || simperiumKey.length == 0) {
+    // treat NSNull like nil
+    if (!simperiumKey || [simperiumKey isEqual:[NSNull null]] || simperiumKey.length == 0) {
         return nil;
     }
     


### PR DESCRIPTION
Server may sometime send null for a field. This is a bug server side that should be fixed but adding crash guard like we do with SPMemberDate. See commit 02ea5cb